### PR TITLE
Update stroke to match to the border color

### DIFF
--- a/Sources/NeoBrutalism/Common/NeoBrutalismBoxModifier.swift
+++ b/Sources/NeoBrutalism/Common/NeoBrutalismBoxModifier.swift
@@ -17,7 +17,7 @@ struct NBBoxModifier: ViewModifier {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: theme.borderRadius)
-                    .stroke(Color.black, lineWidth: theme.borderWidth)
+                    .stroke(theme.border, lineWidth: theme.borderWidth)
             )
     }
 }


### PR DESCRIPTION
When trying to create inverted theme (meaning white shadows and borders), the border remains black due to constant in the code. this PR change it to match the shadow as I believe that the shadow and the border should be in the same color.